### PR TITLE
Add spec value for endEntityName in Issuer/ClusterIssuer CRD, and add support for annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,9 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 # Build the manager image for local development. This image is not intended to be used in production.
 # Then, install it into the K8s cluster
 .PHONY: deploy-local
-deploy-local: ## Build docker image with the manager.
-	docker build -t ejbca-issuer-dev:latest -f Dockerfile.local .
-	make manifests
-	make kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+deploy-local: manifests kustomize ## Build docker image with the manager.
+	docker build -t ejbca-issuer-dev:latest -f Dockerfile .
+	cd config/manager && $(KUSTOMIZE) edit set image controller=ejbca-issuer-dev:latest
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/api/v1alpha1/issuer_types.go
+++ b/api/v1alpha1/issuer_types.go
@@ -46,6 +46,20 @@ type IssuerSpec struct {
 	// the client trust roots for the EJBCA issuer.
 	// +optional
 	CaBundleSecretName string `json:"caBundleSecretName"`
+
+	// Optional field that overrides the default for how the EJBCA issuer should determine the
+	// name of the end entity to reference or create when signing certificates.
+	// The options are:
+	//* cn: Use the CommonName from the CertificateRequest's DN
+	//* dns: Use the first DNSName from the CertificateRequest's DNSNames SANs
+	//* uri: Use the first URI from the CertificateRequest's URI Sans
+	//* ip: Use the first IPAddress from the CertificateRequest's IPAddresses SANs
+	//* certificateName: Use the value of the CertificateRequest's certificateName annotation
+	// If none of the above options are used but endEntityName is populated, the
+	// value of endEntityName will be used as the end entity name. If endEntityName
+	// is not populated, the default tree listed in the EJBCA documentation will be used.
+	// +optional
+	EndEntityName string `json:"endEntityName"`
 }
 
 // IssuerStatus defines the observed state of Issuer

--- a/config/crd/bases/ejbca-issuer.keyfactor.com_clusterissuers.yaml
+++ b/config/crd/bases/ejbca-issuer.keyfactor.com_clusterissuers.yaml
@@ -51,6 +51,20 @@ spec:
                   resource namespace', which is set as a flag on the controller component
                   (and defaults to the namespace that the controller runs in).
                 type: string
+              endEntityName:
+                description: 'Optional field that overrides the default for how the
+                  EJBCA issuer should determine the name of the end entity to reference
+                  or create when signing certificates. The options are: * cn: Use
+                  the CommonName from the CertificateRequest''s DN * dns: Use the
+                  first DNSName from the CertificateRequest''s DNSNames SANs * uri:
+                  Use the first URI from the CertificateRequest''s URI Sans * ip:
+                  Use the first IPAddress from the CertificateRequest''s IPAddresses
+                  SANs * certificateName: Use the value of the CertificateRequest''s
+                  certificateName annotation If none of the above options are used
+                  but endEntityName is populated, the value of endEntityName will
+                  be used as the end entity name. If endEntityName is not populated,
+                  the default tree listed in the EJBCA documentation will be used.'
+                type: string
               endEntityProfileName:
                 type: string
               hostname:

--- a/config/crd/bases/ejbca-issuer.keyfactor.com_issuers.yaml
+++ b/config/crd/bases/ejbca-issuer.keyfactor.com_issuers.yaml
@@ -51,6 +51,20 @@ spec:
                   resource namespace', which is set as a flag on the controller component
                   (and defaults to the namespace that the controller runs in).
                 type: string
+              endEntityName:
+                description: 'Optional field that overrides the default for how the
+                  EJBCA issuer should determine the name of the end entity to reference
+                  or create when signing certificates. The options are: * cn: Use
+                  the CommonName from the CertificateRequest''s DN * dns: Use the
+                  first DNSName from the CertificateRequest''s DNSNames SANs * uri:
+                  Use the first URI from the CertificateRequest''s URI Sans * ip:
+                  Use the first IPAddress from the CertificateRequest''s IPAddresses
+                  SANs * certificateName: Use the value of the CertificateRequest''s
+                  certificateName annotation If none of the above options are used
+                  but endEntityName is populated, the value of endEntityName will
+                  be used as the end entity name. If endEntityName is not populated,
+                  the default tree listed in the EJBCA documentation will be used.'
+                type: string
               endEntityProfileName:
                 type: string
               hostname:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: m8rmclarenkf/ejbca-cert-manager-external-issuer-controller
-  newTag: v1.2.2
+  newName: ejbca-issuer-dev
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - --leader-elect
         image: controller:latest
-        #imagePullPolicy: Never # TODO dev field
+        imagePullPolicy: Never # TODO dev field
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.6.1
 	github.com/onsi/gomega v1.24.2
-	github.com/stretchr/testify v1.8.2
+	github.com/stretchr/testify v1.8.4
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.3
 	k8s.io/client-go v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/internal/controllers/certificaterequest_controller_test.go
+++ b/internal/controllers/certificaterequest_controller_test.go
@@ -118,7 +118,7 @@ func TestCertificateRequestReconcile(t *testing.T) {
 					},
 				},
 			},
-			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string][]byte, map[string][]byte) (signer.Signer, error) {
+			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string]string, map[string][]byte, map[string][]byte) (signer.Signer, error) {
 				return &fakeSigner{}, nil
 			},
 			expectedReadyConditionStatus: cmmeta.ConditionTrue,
@@ -169,7 +169,7 @@ func TestCertificateRequestReconcile(t *testing.T) {
 					},
 				},
 			},
-			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string][]byte, map[string][]byte) (signer.Signer, error) {
+			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string]string, map[string][]byte, map[string][]byte) (signer.Signer, error) {
 				return &fakeSigner{}, nil
 			},
 			clusterResourceNamespace:     "kube-system",
@@ -435,7 +435,7 @@ func TestCertificateRequestReconcile(t *testing.T) {
 					},
 				},
 			},
-			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string][]byte, map[string][]byte) (signer.Signer, error) {
+			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string]string, map[string][]byte, map[string][]byte) (signer.Signer, error) {
 				return nil, errors.New("simulated signer builder error")
 			},
 			expectedError:                errSignerBuilder,
@@ -486,7 +486,7 @@ func TestCertificateRequestReconcile(t *testing.T) {
 					},
 				},
 			},
-			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string][]byte, map[string][]byte) (signer.Signer, error) {
+			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string]string, map[string][]byte, map[string][]byte) (signer.Signer, error) {
 				return &fakeSigner{errSign: errors.New("simulated sign error")}, nil
 			},
 			expectedError:                errSignerSign,
@@ -533,7 +533,7 @@ func TestCertificateRequestReconcile(t *testing.T) {
 					},
 				},
 			},
-			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string][]byte, map[string][]byte) (signer.Signer, error) {
+			Builder: func(context.Context, *ejbcaissuer.IssuerSpec, map[string]string, map[string][]byte, map[string][]byte) (signer.Signer, error) {
 				return &fakeSigner{}, nil
 			},
 			expectedFailureTime: nil,

--- a/internal/controllers/issuer_controller.go
+++ b/internal/controllers/issuer_controller.go
@@ -83,16 +83,21 @@ func (r *IssuerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		return ctrl.Result{}, nil
 	}
 
-	name, issuerSpec, issuerStatus, err := issuerutil.GetSpecAndStatus(issuer)
+	issuerSpec, issuerStatus, err := issuerutil.GetSpecAndStatus(issuer)
 	if err != nil {
 		log.Error(err, "Unexpected error while getting issuer spec and status. Not retrying.")
 		return ctrl.Result{}, nil
 	}
 
+	name, err := issuerutil.GetName(issuer)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Always attempt to update the Ready condition
 	defer func() {
 		if err != nil {
-			issuerutil.SetReadyCondition(ctx, name, r.Kind, issuerStatus, ejbcaissuer.ConditionFalse, issuerReadyConditionReason, err.Error())
+			issuerutil.SetIssuerReadyCondition(ctx, name, r.Kind, issuerStatus, ejbcaissuer.ConditionFalse, issuerReadyConditionReason, err.Error())
 		}
 		if updateErr := r.Status().Update(ctx, issuer); updateErr != nil {
 			err = utilerrors.NewAggregate([]error{err, updateErr})
@@ -101,7 +106,7 @@ func (r *IssuerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	}()
 
 	if ready := issuerutil.GetReadyCondition(issuerStatus); ready == nil {
-		issuerutil.SetReadyCondition(ctx, name, r.Kind, issuerStatus, ejbcaissuer.ConditionUnknown, issuerReadyConditionReason, "First seen")
+		issuerutil.SetIssuerReadyCondition(ctx, name, r.Kind, issuerStatus, ejbcaissuer.ConditionUnknown, issuerReadyConditionReason, "First seen")
 		return ctrl.Result{}, nil
 	}
 
@@ -148,7 +153,7 @@ func (r *IssuerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		return ctrl.Result{}, fmt.Errorf("%w: %v", errHealthCheckerCheck, err)
 	}
 
-	issuerutil.SetReadyCondition(ctx, name, r.Kind, issuerStatus, ejbcaissuer.ConditionTrue, issuerReadyConditionReason, "Success")
+	issuerutil.SetIssuerReadyCondition(ctx, name, r.Kind, issuerStatus, ejbcaissuer.ConditionTrue, issuerReadyConditionReason, "Success")
 	return ctrl.Result{RequeueAfter: defaultHealthCheckInterval}, nil
 }
 

--- a/internal/controllers/issuer_controller_test.go
+++ b/internal/controllers/issuer_controller_test.go
@@ -273,7 +273,7 @@ func TestIssuerReconcile(t *testing.T) {
 				issuer, err := controller.newIssuer()
 				require.NoError(t, err)
 				require.NoError(t, fakeClient.Get(context.TODO(), tc.name, issuer))
-				_, _, issuerStatus, err := issuerutil.GetSpecAndStatus(issuer)
+				_, issuerStatus, err := issuerutil.GetSpecAndStatus(issuer)
 				require.NoError(t, err)
 				assertIssuerHasReadyCondition(t, tc.expectedReadyConditionStatus, issuerStatus)
 			}

--- a/internal/issuer/signer/signer_test.go
+++ b/internal/issuer/signer/signer_test.go
@@ -27,6 +27,9 @@ import (
 	"encoding/pem"
 	"fmt"
 	ejbcaissuer "github.com/Keyfactor/ejbca-issuer/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -80,6 +83,8 @@ func TestEjbcaHealthCheckerFromIssuerAndSecretData(t *testing.T) {
 }
 
 func TestEjbcaSignerFromIssuerAndSecretData(t *testing.T) {
+	ctx := context.Background()
+
 	pathToClientCert := os.Getenv("EJBCA_CLIENT_CERT_PATH")
 	pathToCaCert := os.Getenv("EJBCA_CA_CERT_PATH")
 	hostname := os.Getenv("EJBCA_HOSTNAME")
@@ -127,52 +132,293 @@ func TestEjbcaSignerFromIssuerAndSecretData(t *testing.T) {
 		caSecretData["tls.crt"] = caCertBytes
 	}
 
-	// Create the signer
-	signer, err := EjbcaSignerFromIssuerAndSecretData(context.Background(), &spec, authSecretData, caSecretData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("No Annotations", func(t *testing.T) {
+		// Create the signer
+		signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, make(map[string]string), authSecretData, caSecretData)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// Generate a CSR
-	csr, err := generateCSR(ejbcaCsrDn)
-	if err != nil {
-		t.Fatal(err)
-	}
+		// Generate a CSR
+		csr, _, err := generateCSR(ejbcaCsrDn, []string{""}, []string{""}, []string{""})
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	signedCert, err := signer.Sign(context.Background(), csr)
-	if err != nil {
-		return
-	}
+		signedCert, err := signer.Sign(context.Background(), csr)
+		if err != nil {
+			return
+		}
 
-	t.Log(string(signedCert))
+		t.Log(fmt.Sprintf("Signed certificate: %s", string(signedCert)))
+	})
+
+	t.Run("With Annotations", func(t *testing.T) {
+		// Create test annotations
+		annotations := map[string]string{
+			"ejbca-issuer.keyfactor.com/certificateAuthorityName": "TestCertificateAuthority",
+			"ejbca-issuer.keyfactor.com/certificateProfileName":   "TestCertificateProfile",
+			"ejbca-issuer.keyfactor.com/endEntityName":            "TestEndEntity",
+			"ejbca-issuer.keyfactor.com/endEntityProfileName":     "TestEndEntityProfile",
+		}
+
+		// Create the signer
+		signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, annotations, authSecretData, caSecretData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, "TestCertificateAuthority", signer.certificateAuthorityName)
+		assert.Equal(t, "TestCertificateProfile", signer.certificateProfileName)
+		assert.Equal(t, "TestEndEntity", signer.endEntityName)
+		assert.Equal(t, "TestEndEntityProfile", signer.endEntityProfileName)
+	})
+
+	// Test the default end entity name conditionals
+	t.Run("Default End Entity Name Tests", func(t *testing.T) {
+
+		// Test when endEntityName is not set
+		t.Run("endEntityName is not set", func(t *testing.T) {
+			spec.EndEntityName = ""
+
+			// Create the signer
+			signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, make(map[string]string), authSecretData, caSecretData)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Run("CN", func(t *testing.T) {
+				// Generate a CSR
+				_, csr, err := generateCSR("CN=purplecat.example.com", []string{"reddog.example.com"}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, "purplecat.example.com", signer.getEndEntityName(ctx, csr))
+			})
+
+			t.Run("DNS", func(t *testing.T) {
+				// Generate a CSR
+				_, csr, err := generateCSR("", []string{"reddog.example.com"}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, signer.getEndEntityName(ctx, csr), "reddog.example.com")
+			})
+
+			t.Run("URI", func(t *testing.T) {
+				// Generate a CSR
+				_, csr, err := generateCSR("", []string{""}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, "https://blueelephant.example.com", signer.getEndEntityName(ctx, csr))
+			})
+
+			t.Run("IP", func(t *testing.T) {
+				// Generate a CSR
+				_, csr, err := generateCSR("", []string{""}, []string{""}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, signer.getEndEntityName(ctx, csr), "192.168.1.1")
+			})
+		})
+
+		// Test when endEntityName is set
+		t.Run("endEntityName is set", func(t *testing.T) {
+			t.Run("CN", func(t *testing.T) {
+				spec.EndEntityName = "cn"
+
+				// Create the signer
+				signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, make(map[string]string), authSecretData, caSecretData)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Generate a CSR
+				_, csr, err := generateCSR("CN=purplecat.example.com", []string{"reddog.example.com"}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, signer.getEndEntityName(ctx, csr), "purplecat.example.com")
+			})
+
+			t.Run("DNS", func(t *testing.T) {
+				spec.EndEntityName = "dns"
+
+				// Create the signer
+				signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, make(map[string]string), authSecretData, caSecretData)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Generate a CSR
+				_, csr, err := generateCSR("CN=purplecat.example.com", []string{"reddog.example.com"}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, signer.getEndEntityName(ctx, csr), "reddog.example.com")
+			})
+
+			t.Run("URI", func(t *testing.T) {
+				spec.EndEntityName = "uri"
+
+				// Create the signer
+				signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, make(map[string]string), authSecretData, caSecretData)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Generate a CSR
+				_, csr, err := generateCSR("CN=purplecat.example.com", []string{"reddog.example.com"}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, signer.getEndEntityName(ctx, csr), "https://blueelephant.example.com")
+			})
+
+			t.Run("IP", func(t *testing.T) {
+				spec.EndEntityName = "ip"
+
+				// Create the signer
+				signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, make(map[string]string), authSecretData, caSecretData)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Generate a CSR
+				_, csr, err := generateCSR("CN=purplecat.example.com", []string{"reddog.example.com"}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, signer.getEndEntityName(ctx, csr), "192.168.1.1")
+			})
+
+			t.Run("certificateName", func(t *testing.T) {
+				spec.EndEntityName = "certificateName"
+
+				// Create test annotations
+				annotations := map[string]string{
+					"cert-manager.io/certificate-name": "test-cert-manager-certificate",
+				}
+
+				// Create the signer
+				signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, annotations, authSecretData, caSecretData)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Generate a CSR
+				_, csr, err := generateCSR("CN=purplecat.example.com", []string{"reddog.example.com"}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, signer.getEndEntityName(ctx, csr), "test-cert-manager-certificate")
+			})
+
+			t.Run("endEntityName", func(t *testing.T) {
+				spec.EndEntityName = "Hello World!"
+
+				// Create the signer
+				signer, err := ejbcaSignerFromIssuerAndSecretData(context.Background(), &spec, make(map[string]string), authSecretData, caSecretData)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Generate a CSR
+				_, csr, err := generateCSR("CN=purplecat.example.com", []string{"reddog.example.com"}, []string{"https://blueelephant.example.com"}, []string{"192.168.1.1"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, signer.getEndEntityName(ctx, csr), "Hello World!")
+			})
+		})
+	})
 }
 
-func generateCSR(subject string) ([]byte, error) {
+func generateCSR(subject string, dnsNames []string, uris []string, ipAddresses []string) ([]byte, *x509.CertificateRequest, error) {
 	keyBytes, _ := rsa.GenerateKey(rand.Reader, 2048)
 
 	subj, err := parseSubjectDN(subject, false)
 	if err != nil {
-		return make([]byte, 0, 0), err
+		return nil, nil, err
 	}
 
 	template := x509.CertificateRequest{
 		Subject:            subj,
 		SignatureAlgorithm: x509.SHA256WithRSA,
 	}
-	var csrBuf bytes.Buffer
-	csrBytes, _ := x509.CreateCertificateRequest(rand.Reader, &template, keyBytes)
-	err = pem.Encode(&csrBuf, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
-	if err != nil {
-		return make([]byte, 0, 0), err
+
+	if len(dnsNames) > 0 {
+		template.DNSNames = dnsNames
 	}
 
-	return csrBuf.Bytes(), nil
+	// Parse and add URIs
+	var uriPointers []*url.URL
+	for _, u := range uris {
+		if u == "" {
+			continue
+		}
+		uriPointer, err := url.Parse(u)
+		if err != nil {
+			return nil, nil, err
+		}
+		uriPointers = append(uriPointers, uriPointer)
+	}
+	template.URIs = uriPointers
+
+	// Parse and add IPAddresses
+	var ipAddrs []net.IP
+	for _, ipStr := range ipAddresses {
+		if ipStr == "" {
+			continue
+		}
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			return nil, nil, fmt.Errorf("invalid IP address: %s", ipStr)
+		}
+		ipAddrs = append(ipAddrs, ip)
+	}
+	template.IPAddresses = ipAddrs
+
+	// Generate the CSR
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, keyBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var csrBuf bytes.Buffer
+	err = pem.Encode(&csrBuf, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	parsedCSR, err := x509.ParseCertificateRequest(csrBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return csrBuf.Bytes(), parsedCSR, nil
 }
 
 // Function that turns subject string into pkix.Name
 // EG "C=US,ST=California,L=San Francisco,O=HashiCorp,OU=Engineering,CN=example.com"
 func parseSubjectDN(subject string, randomizeCn bool) (pkix.Name, error) {
 	var name pkix.Name
+
+	if subject == "" {
+		return name, nil
+	}
 
 	// Split the subject into its individual parts
 	parts := strings.Split(subject, ",")


### PR DESCRIPTION
Summary of additions:

## EJBCA End Entity Name Configuration
The endEntityName field in the Issuer and ClusterIssuer resource spec allows you to configure how the End Entity Name is selected when issuing certificates through EJBCA. This field offers flexibility by allowing you to select different components from the Certificate Signing Request (CSR) or other contextual data as the End Entity Name.

### Configurable Options
Here are the different options you can set for endEntityName:

* **`cn`:** Uses the Common Name from the CSR's Distinguished Name.
* **`dns`:** Uses the first DNS Name from the CSR's Subject Alternative Names (SANs).
* **`uri`:** Uses the first URI from the CSR's Subject Alternative Names (SANs).
* **`ip`:** Uses the first IP Address from the CSR's Subject Alternative Names (SANs).
* **`certificateName`:** Uses the name of the cert-manager.io/Certificate object.
* **Custom Value:** Any other string will be directly used as the End Entity Name.

### Default Behavior
If the endEntityName field is not explicitly set, the EJBCA Issuer will attempt to determine the End Entity Name using the following default behavior:

* **First, it will try to use the Common Name:** It looks at the Common Name from the CSR's Distinguished Name.
* **If the Common Name is not available, it will use the first DNS Name:** It looks at the first DNS Name from the CSR's Subject Alternative Names (SANs).
* **If the DNS Name is not available, it will use the first URI:** It looks at the first URI from the CSR's Subject Alternative Names (SANs).
* **If the URI is not available, it will use the first IP Address:** It looks at the first IP Address from the CSR's Subject Alternative Names (SANs).
* **If none of the above are available, it will use the name of the cert-manager.io/Certificate object:** It defaults to the name of the certificate object. 

If the Issuer is unable to determine a valid End Entity Name through these steps, an error will be logged and no End Entity Name will be set.

## Annotation Overrides for Issuer and ClusterIssuer Resources
The Keyfactor EJBCA external issuer for cert-manager allows you to override default settings in the Issuer and ClusterIssuer resources through the use of annotations. This gives you more granular control on a per-Certificate/CertificateRequest basis.

### Supported Annotations
Here are the supported annotations that can override the default values:

- **`ejbca-issuer.keyfactor.com/endEntityName`**: Overrides the `endEntityName` field from the resource spec. Allowed values include `"cn"`, `"dns"`, `"uri"`, `"ip"`, and `"certificateName"`, or any custom string.

    ```yaml
    ejbca-issuer.keyfactor.com/endEntityName: "dns"
    ```

- **`ejbca-issuer.keyfactor.com/certificateAuthorityName`**: Specifies the Certificate Authority (CA) name to use, overriding the default CA specified in the resource spec.

    ```yaml
    ejbca-issuer.keyfactor.com/certificateAuthorityName: "ManagementCA"
    ```

- **`ejbca-issuer.keyfactor.com/certificateProfileName`**: Specifies the Certificate Profile name to use, overriding the default profile specified in the resource spec.

    ```yaml
    ejbca-issuer.keyfactor.com/certificateProfileName: "tlsServerAuth"
    ```

- **`ejbca-issuer.keyfactor.com/endEntityProfileName`**: Specifies the End Entity Profile name to use, overriding the default profile specified in the resource spec.

    ```yaml
    ejbca-issuer.keyfactor.com/endEntityProfileName: "eep"
    ```

### How to Apply Annotations

To apply these annotations, include them in the metadata section of your CertificateRequest resource:

```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  annotations:
    ejbca-issuer.keyfactor.com/endEntityName: "dns"
    ejbca-issuer.keyfactor.com/certificateAuthorityName: "ManagementCA"
    # ... other annotations
spec:
# ... rest of the spec
```