### PR TITLE
v1.3.2: Upgrade packages, implement metrics.metricsAddress and containerPorts in Helm chart, refactor release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,43 +1,68 @@
-name: helm_release
+name: Build and Release Helm Chart
 on:
   pull_request:
     branches:
       - 'v*'
     types:
+      # action should run when the pull request is closed
+      # (regardless of whether it was merged or just closed)
       - closed
+      # Make sure the action runs every time new commits are
+      # pushed to the pull request's branch
+      - synchronize
+
 jobs:
   helm:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
-      - name: Extract Version Tag
-        id: extract_version
-        run: /bin/bash -c 'echo ::set-output name=VERSION::$(echo ${GITHUB_REF##*/} | cut -c2-)'
+      - name: Set IMAGE_NAME
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
-      - name: Checkout
-        uses: actions/checkout@v3
+      # Checkout code
+      # https://github.com/actions/checkout
+      - name: Checkout code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      # Extract metadata (tags, labels) to use in Helm chart
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Set version from DOCKER_METADATA_OUTPUT_VERSION as environment variable
+      - name: Set Version
+        run: |
+          echo "VERSION=${DOCKER_METADATA_OUTPUT_VERSION:1}" >> $GITHUB_ENV
 
       # Change version and appVersion in Chart.yaml to the tag in the closed PR
       - name: Update Helm App/Chart Version
         shell: bash
         run: |
-          sed -i "s/^version: .*/version: ${{ steps.extract_version.outputs.VERSION }}/g" deploy/charts/ejbca-cert-manager-issuer/Chart.yaml
-          sed -i "s/^appVersion: .*/appVersion: \"${{ steps.extract_version.outputs.VERSION }}\"/g" deploy/charts/ejbca-cert-manager-issuer/Chart.yaml
+          sed -i "s/^version: .*/version: ${{ env.VERSION }}/g" deploy/charts/ejbca-cert-manager-issuer/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${{ env.DOCKER_METADATA_OUTPUT_VERSION }}\"/g" deploy/charts/ejbca-cert-manager-issuer/Chart.yaml
 
+      # Setup Helm
+      # https://github.com/Azure/setup-helm
+      - name: Install Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Helm requires an ident name to be set for chart-releaser to work
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-
+      # Build and release Helm chart to GitHub Pages
+      # https://github.com/helm/chart-releaser-action
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          pages_branch: gh-pages
           charts_dir: deploy/charts
-          mark_as_latest: true
-          packages_with_index: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+on: [workflow_dispatch, push, pull_request]
+jobs:
+  build:
+    name: Build and Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Checkout code
+      # https://github.com/actions/checkout
+      - name: Checkout code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      # Setup GoLang build environment
+      # https://github.com/actions/setup-go
+      - name: Set up Go 1.x
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # Download dependencies
+      - run: go mod download
+
+      # Build Go binary
+      - run: go build -v .
+
+      # Run Go linters
+      # https://github.com/golangci/golangci-lint-action
+      - name: Run linters
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        with:
+          version: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v1.3.2
+
+## Features
+* feat(helm): Rename `secureMetrics` to `metrics` and add `metrics.secure` and `metrics.metricsAddress` as configuration values. This way, Prometheus can scrape the controller manager metrics without the secure metrics proxy.
+* feat(helm): Add configuration element in Helm chart default values file to configure container ports on the controller manager container.
+
+## Fixes
+* fix(deps): Update golang.org/x/net to v0.19.0
+* fix(dockerfile): Upgrade builder image to golang:1.20 to address [CVE-2023-38408](https://scout.docker.com/vulnerabilities/id/CVE-2023-38408?utm_source=hub&utm_medium=ExternalLink&_gl=1*hbs4zp*_ga*MTU5MTQ4Mzk3MC4xNjkxNDI2NjAy*_ga_XJWPQMJYHQ*MTcwMzE4NzcyNC4xMDEuMS4xNzAzMTg4OTUxLjM3LjAuMA..)
+
 # v1.3.1
 
 ## Features

--- a/deploy/charts/ejbca-cert-manager-issuer/README.md
+++ b/deploy/charts/ejbca-cert-manager-issuer/README.md
@@ -29,8 +29,6 @@ helm repo update
 helm install ejbca-cert-manager-issuer ejbca-issuer/ejbca-cert-manager-issuer \
     --namespace ejbca-issuer-system \
     --create-namespace \
-    --set image.repository=<your container registry>/keyfactor/ejbca-cert-manager-issuer \
-    --set image.tag=<tag>
     # --set image.pullPolicy=Never # Only required if using a local image
 ```
 
@@ -40,8 +38,6 @@ Modifications can be made by overriding the default values in the `values.yaml` 
 helm install ejbca-cert-manager-issuer ejbca-issuer/ejbca-cert-manager-issuer \
     --namespace ejbca-issuer-system \
     --create-namespace \
-    --set image.repository=<your container registry>/keyfactor/ejbca-cert-manager-issuer \
-    --set image.tag=<tag>
     --set replicaCount=2
 ```
 
@@ -49,10 +45,6 @@ Modifications can also be made by modifying the `values.yaml` file directly. For
 
 ```yaml
 cat <<EOF > override.yaml
-image:
-    repository: <your container registry>/keyfactor/ejbca-cert-manager-issuer
-    pullPolicy: Never
-    tag: "latest"
 secretConfig:
     useClusterRoleForSecretAccess: true
 EOF
@@ -87,8 +79,9 @@ The following table lists the configurable parameters of the `ejbca-cert-manager
 | `podAnnotations`                             | Annotations for the pod                                                                             | `{}`                                                         |
 | `podSecurityContext.runAsNonRoot`            | Run pod as non-root                                                                                 | `true`                                                       |
 | `securityContext`                            | Security context for the pod                                                                        | `{}` (with commented out options)                            |
-| `secureMetrics.enabled`                      | Enable secure metrics via the Kube RBAC Proy                                                        | `false`                                                      |
+| `metrics.secure`                      | Enable secure metrics via the Kube RBAC Proy                                                        | `false`                                                      |
 | `resources`                                  | CPU/Memory resource requests/limits                                                                 | `{}` (with commented out options)                            |
 | `nodeSelector`                               | Node labels for pod assignment                                                                      | `{}`                                                         |
 | `tolerations`                                | Tolerations for pod assignment                                                                      | `[]`                                                         |
 | `secretConfig.useClusterRoleForSecretAccess` | Specifies if the ServiceAccount should be granted access to the Secret resource using a ClusterRole | `false`                                                      |
+| `containerPorts`                               | Defines the ports that the controller manager container exposes. If you change this, you will need to configure your Prometheus instance to scrape these metrics. | `[{"containerPort": 8080, "name": "http-metrics", "protocol": "TCP"}]` |

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/clusterrole.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/clusterrole.yaml
@@ -45,7 +45,7 @@ rules:
       - issuers/finalizers
     verbs:
       - update
-{{- if .Values.secureMetrics.enabled }}
+{{- if .Values.metrics.secure }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/clusterrolebinding.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/clusterrolebinding.yaml
@@ -12,7 +12,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "ejbca-cert-manager-issuer.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- if .Values.secureMetrics.enabled }}
+{{- if .Values.metrics.secure }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/deployment.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if .Values.secureMetrics.enabled }}
+        {{- if .Values.metrics.secure }}
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -53,7 +53,7 @@ spec:
         {{- end }}
         - args:
             - --health-probe-bind-address=:8081
-            - --metrics-bind-address=127.0.0.1:8080
+            - --metrics-bind-address={{ .Values.metrics.metricsAddress }}
             - --leader-elect
             {{- if .Values.secretConfig.useClusterRoleForSecretAccess}}
             - --secret-access-granted-at-cluster-level
@@ -75,6 +75,10 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- with .Values.containerPorts }}
+          ports:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/service.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secureMetrics.enabled }}
+{{- if .Values.metrics.secure }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/charts/ejbca-cert-manager-issuer/values.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: m8rmclarenkf/ejbca-cert-manager-external-issuer-controller
+  repository: keyfactor/ejbca-cert-manager-issuer
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -13,10 +13,24 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# Whether to enable and configure the kube-rbac-proxy sidecar for authorized and authenticated
-# use of the /metrics endpoint by Prometheus.
-secureMetrics:
-  enabled: false
+metrics:
+  # Whether to enable and configure the kube-rbac-proxy sidecar for authorized and authenticated
+  # use of the /metrics endpoint by Prometheus.
+  secure: false
+  # The address and port to expose the metrics endpoint. This will only be configured as a container
+  # port; you will need to configure your Prometheus instance to scrape this endpoint.
+  # Example: ":8080" (default)
+  # Example: "127.0.0.1:8080" (if secure: true)
+  metricsAddress: ":8080"
+
+# Define the ports that the controller manager container exposes.
+# If you change this, you will need to configure your Prometheus instance to scrape these metrics.
+# If metrics.secure is true, Prometheus must scrape port 8443 with HTTPS.
+containerPorts:
+  # Values must be in the format expected by the ports field of the Kubernetes v1 core API type ContainerPort.
+  - containerPort: 8080
+    name: http-metrics
+    protocol: TCP
 
 secretConfig:
   # If true, when using Issuer resources, the credential secret must be created in the same namespace as the

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+<a href="https://kubernetes.io">
+    <img src="https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png" alt="Terraform logo" title="K8s" align="left" height="50" />
+</a>
+
+# Keyfactor EJBCA Issuer for cert-manager
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/Keyfactor/ejbca-cert-manager-issuer)](https://goreportcard.com/report/github.com/Keyfactor/ejbca-cert-manager-issuer)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
+
+The EJBCA external issuer for cert-manager allows users to enroll certificates from Keyfactor EJBCA using cert-manager.
+
+Cert-manager is a native Kubernetes certificate management controller which allows applications to get their certificates from a variety of CAs (Certification Authorities). It ensures certificates are valid and up to date, it also attempts to renew certificates at a configured time before expiration.
+
+## EJBCA API Usage
+The EJBCA Issuer for cert-manager requires the following API endpoints:
+* `/ejbca-rest-api/v1/certificate/pkcs10enroll`
+* `/ejbca/ejbca-rest-api/v1/certificate/status`
+
+## Docs
+
+* [Installation](docs/install.md)
+* Usage
+    * [Usage](docs/config_usage.md)
+    * [Customization](docs/annotations.md)
+    * [End Entity Name Selection](docs/endentitynamecustomization.md)
+* [Testing the Source](docs/testing.md)
+* [License](LICENSE)

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,24 +32,9 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 ###### :pushpin: Running the static cert-manager configuration is not recommended for production use. For more information, see [Installing cert-manager](https://cert-manager.io/docs/installation/).
 
-### Building the Container Image
-
-The cert-manager external issuer for Keyfactor EJBCA is distributed as source code, and the container must be built manually. The container image can be built using the following command:
-```shell
-make docker-build DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=keyfactor/ejbca-cert-manager-issuer
-```
-
-###### :pushpin: The container image can be built using Docker Buildx by running `make docker-buildx`. This will build the image for all supported platforms.
-
-To push the container image to a container registry, run the following command:
-```shell
-docker login <your container registry>
-make docker-push DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=keyfactor/ejbca-cert-manager-issuer
-```
-
 ### Installation from Helm Chart
 
-The cert-manager external issuer for Keyfactor EJBCA can also be installed using a Helm chart. The chart is available in the [EJBCA cert-manager Helm repository](https://keyfactor.github.io/ejbca-cert-manager-issuer/).
+The cert-manager external issuer for Keyfactor EJBCA is installed using a Helm chart. The chart is available in the [EJBCA cert-manager Helm repository](https://keyfactor.github.io/ejbca-cert-manager-issuer/).
 
 1. Add the Helm repository:
 
@@ -64,8 +49,6 @@ The cert-manager external issuer for Keyfactor EJBCA can also be installed using
     helm install ejbca-cert-manager-issuer ejbca-issuer/ejbca-cert-manager-issuer \
         --namespace ejbca-issuer-system \
         --create-namespace \
-        --set image.repository=<your container registry>/keyfactor/ejbca-cert-manager-issuer \
-        --set image.tag=<tag>
         # --set image.pullPolicy=Never # Only required if using a local image
     ```
 
@@ -75,8 +58,6 @@ The cert-manager external issuer for Keyfactor EJBCA can also be installed using
         helm install ejbca-cert-manager-issuer ejbca-issuer/ejbca-cert-manager-issuer \
             --namespace ejbca-issuer-system \
             --create-namespace \
-            --set image.repository=<your container registry>/keyfactor/ejbca-cert-manager-issuer \
-            --set image.tag=<tag>
             --set replicaCount=2
         ```
 
@@ -84,10 +65,6 @@ The cert-manager external issuer for Keyfactor EJBCA can also be installed using
 
         ```yaml
         cat <<EOF > override.yaml
-        image:
-            repository: <your container registry>/keyfactor/ejbca-cert-manager-issuer
-            pullPolicy: Never
-            tag: "latest"
         secretConfig:
             useClusterRoleForSecretAccess: true
         EOF


### PR DESCRIPTION
# v1.3.2

## Features
* feat(helm): Rename `secureMetrics` to `metrics` and add `metrics.secure` and `metrics.metricsAddress` as configuration values. This way, Prometheus can scrape the controller manager metrics without the secure metrics proxy.
* feat(helm): Add configuration element in Helm chart default values file to configure container ports on the controller manager container.

## Fixes
* fix(deps): Update golang.org/x/net to v0.19.0
* fix(dockerfile): Upgrade builder image to golang:1.20 to address [CVE-2023-38408](https://scout.docker.com/vulnerabilities/id/CVE-2023-38408?utm_source=hub&utm_medium=ExternalLink&_gl=1*hbs4zp*_ga*MTU5MTQ4Mzk3MC4xNjkxNDI2NjAy*_ga_XJWPQMJYHQ*MTcwMzE4NzcyNC4xMDEuMS4xNzAzMTg4OTUxLjM3LjAuMA..)