### PR TITLE
feat(helm): use helm release namespace for all namespaced resources

### DIFF
--- a/deploy/charts/ejbca-cert-manager-issuer/templates/deployment.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ejbca-cert-manager-issuer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ejbca-cert-manager-issuer.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/role.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/role.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "ejbca-cert-manager-issuer.labels" . | nindent 4 }}
   name: {{ include "ejbca-cert-manager-issuer.name" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - coordination.k8s.io

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/rolebinding.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/rolebinding.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "ejbca-cert-manager-issuer.labels" . | nindent 4 }}
   name: {{ include "ejbca-cert-manager-issuer.name" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/secretrole.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/secretrole.yaml
@@ -4,6 +4,9 @@ metadata:
   labels:
     {{- include "ejbca-cert-manager-issuer.labels" . | nindent 4 }}
   name: {{ include "ejbca-cert-manager-issuer.name" . }}-secret-reader-role
+{{- if not .Values.secretConfig.useClusterRoleForSecretAccess }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 rules:
   - apiGroups:
       - ""
@@ -20,6 +23,9 @@ metadata:
   labels:
     {{- include "ejbca-cert-manager-issuer.labels" . | nindent 4 }}
   name: {{ include "ejbca-cert-manager-issuer.name" . }}-secret-reader-rolebinding
+{{- if not .Values.secretConfig.useClusterRoleForSecretAccess }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ if .Values.secretConfig.useClusterRoleForSecretAccess }}ClusterRole{{ else }}Role{{ end }}

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/service.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "ejbca-cert-manager-issuer.labels" . | nindent 4 }}
   name: {{ include "ejbca-cert-manager-issuer.name" . }}-metrics-service
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: https

--- a/deploy/charts/ejbca-cert-manager-issuer/templates/serviceaccount.yaml
+++ b/deploy/charts/ejbca-cert-manager-issuer/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ejbca-cert-manager-issuer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ejbca-cert-manager-issuer.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
## Explicit namespaced resources namespace value

### Current Behavior

Current behavior is to rely on helm install capabilities to set resources namespace "just in time" during the setup phase.

```
helm install ejbca-cert-manager-issuer ejbca-issuer/ejbca-cert-manager-issuer --namespace ejbca-issuer-system --create-namespace
```

This is working pretty well

### The problem

The problem is that the namespace is not applied if we're doing the same thing using helm template :

```
helm template ejbca-cert-manager-issuer deploy/charts/ejbca-cert-manager-issuer --namespace ejbca-issuer-system --create-namespace > no-ns.yaml
```

```
---
# Source: ejbca-cert-manager-issuer/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ejbca-cert-manager-issuer 
< ! MISSING NAMESPACE HERE ! >
  labels:
    helm.sh/chart: ejbca-cert-manager-issuer-0.1.0
    app.kubernetes.io/name: ejbca-cert-manager-issuer
    app.kubernetes.io/instance: ejbca-cert-manager-issuer
    app.kubernetes.io/version: "v1.3.1"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  ...
```

This is caused by missing namespace value in helm templates for all namespaced resources (example for Deploy resource : https://github.com/Keyfactor/ejbca-cert-manager-issuer/blob/main/deploy/charts/ejbca-cert-manager-issuer/templates/deployment.yaml#L3-L6 )

This PR makes namespace value explicit in every resources that requires it, enabling a nice compatibility with `helm template` workflow.

Thanks !

