### PR TITLE
fix: signer returns separate chain & CA using cert-mgr utils

### DIFF
--- a/internal/controllers/certificaterequest_controller.go
+++ b/internal/controllers/certificaterequest_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/Keyfactor/ejbca-issuer/internal/issuer/signer"
 	issuerutil "github.com/Keyfactor/ejbca-issuer/internal/issuer/util"
 	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -236,12 +237,12 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, fmt.Errorf("%w: %v", errSignerBuilder, err)
 	}
 
-	leaf, chain, err := ejbcaSigner.Sign(ctx, certificateRequest.Spec.Request)
+	chain, ca, err := ejbcaSigner.Sign(ctx, certificateRequest.Spec.Request)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("%w: %v", errSignerSign, err)
 	}
-	certificateRequest.Status.Certificate = leaf
-	certificateRequest.Status.CA = chain
+	certificateRequest.Status.Certificate = chain
+	certificateRequest.Status.CA = ca
 
 	issuerutil.SetCertificateRequestReadyCondition(ctx, &certificateRequest, cmmeta.ConditionTrue, cmapi.CertificateRequestReasonIssued, "Signed")
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Implement a solution for https://github.com/Keyfactor/ejbca-cert-manager-issuer/issues/3

It uses cert-manager pki utils ( https://github.com/cert-manager/cert-manager/blob/master/pkg/util/pki/parse_certificate_chain.go#L50-L68 ) that helps a lot dealing with leaf / chain / root.

It makes ejbca integration with cert-manager smoother and more aligned with certificateSigningRequest expected reconciliation.

It passes all current tests, but please tell me if you feel this is too ugly !
Thanks