### PR TITLE
Use static README

### DIFF
--- a/.github/workflows/keyfactor-workflow.yml
+++ b/.github/workflows/keyfactor-workflow.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-starter-workflow:
-    uses: keyfactor/actions/.github/workflows/starter.yml@v2
+    uses: keyfactor/actions/.github/workflows/starter.yml@ejbca-readme-updates
     secrets:
       token: ${{ secrets.V2BUILDTOKEN}}
       APPROVE_README_PUSH: ${{ secrets.APPROVE_README_PUSH}}

--- a/README.md
+++ b/README.md
@@ -22,15 +22,6 @@ ejbca-cert-manager-issuer is open source and supported on best effort level for 
 
 
 
-<!--EJBCA Community logo -->
-<a href="https://ejbca.org">
-    <img src=".github/images/community-ejbca.png?raw=true)" alt="EJBCA logo" title="EJBCA" height="70" />
-</a>
-<!--EJBCA Enterprise logo -->
-<a href="https://www.keyfactor.com/products/ejbca-enterprise/">
-    <img src=".github/images/keyfactor-ejbca-enterprise.png?raw=true)" alt="EJBCA logo" title="EJBCA" height="70" />
-</a>
-
 # Keyfactor EJBCA Issuer for cert-manager
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/Keyfactor/ejbca-cert-manager-issuer)](https://goreportcard.com/report/github.com/Keyfactor/ejbca-cert-manager-issuer)
@@ -73,5 +64,7 @@ For license information, see **[LICENSE](LICENSE)**.
 ## Related Projects
 
 See all [Keyfactor EJBCA GitHub projects](https://github.com/orgs/Keyfactor/repositories?q=ejbca). 
+
+
 
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,3 @@
-
-# ejbca-cert-manager-issuer
-
-cert-manager external issuer for EJBCA
-
-#### Integration status: Production - Ready for use in production environments.
-
-## About the Keyfactor API Client
-
-This API client allows for programmatic management of Keyfactor resources.
-
-## Support for ejbca-cert-manager-issuer
-
-ejbca-cert-manager-issuer is open source and supported on best effort level for this tool/library/client.  This means customers can report Bugs, Feature Requests, Documentation amendment or questions as well as requests for customer information required for setup that needs Keyfactor access to obtain. Such requests do not follow normal SLA commitments for response or resolution. If you have a support issue, please open a support ticket via the Keyfactor Support Portal at https://support.keyfactor.com/
-
-###### To report a problem or suggest a new feature, use the **[Issues](../../issues)** tab. If you want to contribute actual bug fixes or proposed enhancements, use the **[Pull requests](../../pulls)** tab.
-
----
-
-
----
-
-
-
 # Keyfactor EJBCA Issuer for cert-manager
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/Keyfactor/ejbca-cert-manager-issuer)](https://goreportcard.com/report/github.com/Keyfactor/ejbca-cert-manager-issuer)
@@ -64,7 +40,5 @@ For license information, see **[LICENSE](LICENSE)**.
 ## Related Projects
 
 See all [Keyfactor EJBCA GitHub projects](https://github.com/orgs/Keyfactor/repositories?q=ejbca). 
-
-
 
 

--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://keyfactor.github.io/integration-manifest-schema.json",
-    "integration_type": "api-client",
+    "integration_type": "ejbca",
     "name": "ejbca-cert-manager-issuer",
     "status": "production",
     "link_github":false,

--- a/readme_source.md
+++ b/readme_source.md
@@ -1,12 +1,3 @@
-<!--EJBCA Community logo -->
-<a href="https://ejbca.org">
-    <img src=".github/images/community-ejbca.png?raw=true)" alt="EJBCA logo" title="EJBCA" height="70" />
-</a>
-<!--EJBCA Enterprise logo -->
-<a href="https://www.keyfactor.com/products/ejbca-enterprise/">
-    <img src=".github/images/keyfactor-ejbca-enterprise.png?raw=true)" alt="EJBCA logo" title="EJBCA" height="70" />
-</a>
-
 # Keyfactor EJBCA Issuer for cert-manager
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/Keyfactor/ejbca-cert-manager-issuer)](https://goreportcard.com/report/github.com/Keyfactor/ejbca-cert-manager-issuer)
@@ -49,3 +40,5 @@ For license information, see **[LICENSE](LICENSE)**.
 ## Related Projects
 
 See all [Keyfactor EJBCA GitHub projects](https://github.com/orgs/Keyfactor/repositories?q=ejbca). 
+
+


### PR DESCRIPTION
Using the actions@ejbca-readme-updates branch to bypass readme generation and use a static readme file.