### PR TITLE
Use 3.2.0 of starter workflow

### DIFF
--- a/.github/workflows/keyfactor-workflow.yml
+++ b/.github/workflows/keyfactor-workflow.yml
@@ -11,11 +11,12 @@ on:
 
 jobs:
   call-starter-workflow:
-    uses: keyfactor/actions/.github/workflows/starter.yml@v4
+    uses: keyfactor/actions/.github/workflows/starter.yml@3.2.0
     secrets:
       token: ${{ secrets.V2BUILDTOKEN}}
       gpg_key: ${{ secrets.KF_GPG_PRIVATE_KEY }}
       gpg_pass: ${{ secrets.KF_GPG_PASSPHRASE }}
+      APPROVE_README_PUSH: ${{ secrets.APPROVE_README_PUSH}}
       scan_token: ${{ secrets.SAST_TOKEN }}
       docker-user: ${{ secrets.DOCKER_USER }}
       docker-token:  ${{ secrets.DOCKER_PWD }}


### PR DESCRIPTION
Using 3.2.0 of the starter workflow to fix an issue with the v4 workflow not parsing the integration-manifest correctly.