### PR TITLE
Change builder image to major.minor(1.24) instead of major.minor.patc…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GOIMAGE=golang:1.24.6
+ARG GOIMAGE=golang:1.24
 ARG BASEIMAGE=gcr.io/distroless/static:nonroot
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
…h(1.24.6)

When rebuilding the image now old critical vulnerabilities will not be in the resulting image anymore.


## Describe your changes

Changed the GOIMAGE to only be the 1.24 to resolve critical/high vulnerabilites found in forexample crypto/x509

## How has this been tested?

Build the image and scan it with a vulnerability scanner like trivy, clair or prisma

