### PR TITLE
feat: pass spec.duration to EJBCA as end_time (fixes #128)

### DIFF
--- a/internal/controller/certificaterequest_controller.go
+++ b/internal/controller/certificaterequest_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	ejbcaissuerv1alpha1 "github.com/Keyfactor/ejbca-cert-manager-issuer/api/v1alpha1"
 	"github.com/Keyfactor/ejbca-cert-manager-issuer/internal/ejbca"
@@ -281,6 +282,17 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		caCertBytes = bytes
 	}
 
+	// Compute notAfter from spec.duration if present.
+	// spec.duration is a requested certificate lifetime (e.g. "1128h0m0s").
+	// We add it to the current time to get an absolute notAfter timestamp.
+	// If spec.duration is nil, notAfter is nil and the Certificate Profile
+	// default validity is used instead — existing behaviour is unchanged.
+	var notAfter *time.Time
+	if certificateRequest.Spec.Duration != nil {
+		t := time.Now().Add(certificateRequest.Spec.Duration.Duration).UTC()
+		notAfter = &t
+	}
+
 	signer, err := r.SignerBuilder(ctx,
 		ejbca.WithHostname(issuerSpec.Hostname),
 		ejbca.WithCACerts(caCertBytes),
@@ -290,6 +302,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		ejbca.WithCertificateAuthority(issuerSpec.CertificateAuthorityName),
 		ejbca.WithEndEntityName(issuerSpec.EndEntityName),
 		ejbca.WithAnnotations(certificateRequest.GetAnnotations()),
+		ejbca.WithNotAfter(notAfter),
 	)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("%w: %w", errSignerBuilder, err)

--- a/internal/ejbca/ejbca.go
+++ b/internal/ejbca/ejbca.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/Keyfactor/ejbca-go-client-sdk/api/ejbca"
 	cmpki "github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -85,6 +86,7 @@ type Config struct {
 	endEntityName              string
 	certManagerCertificateName string
 	annotations                map[string]string
+	notAfter                   *time.Time // nil = use Certificate Profile default
 }
 
 func (c *Config) validate(ctx context.Context) error {
@@ -276,6 +278,15 @@ func WithAnnotations(annotations map[string]string) Option {
 	}
 }
 
+// WithNotAfter sets a specific notAfter time for the certificate request.
+// If nil, the Certificate Profile default validity is used.
+// This corresponds to spec.duration on the cert-manager CertificateRequest.
+func WithNotAfter(t *time.Time) Option {
+	return func(s *signer) {
+		s.config.notAfter = t
+	}
+}
+
 func withAuthenticator(newAuthenticator newEjbcaAuthenticatorFunc) Option {
 	return func(s *signer) {
 		s.hooks.newAuthenticator = newAuthenticator
@@ -324,6 +335,17 @@ func (s *signer) Sign(ctx context.Context, csrBytes []byte) ([]byte, []byte, err
 	enroll.SetUsername(ejbcaEeName)
 	enroll.SetPassword(password)
 	enroll.SetIncludeChain(true)
+
+	if s.config.notAfter != nil {
+		// JohnB: end_time is the EJBCA REST API v1 field for validity override.
+		// Required format: "2006-01-02 15:04:05" (UTC, no T separator, no Z suffix).
+		// RFC3339 is rejected by EJBCA with "Ignoring invalid start time format".
+		notAfterStr := s.config.notAfter.UTC().Format("2006-01-02 15:04:05")
+		enroll.AdditionalProperties = map[string]interface{}{
+			"end_time": notAfterStr,
+		}
+		logger.Info("Requesting certificate validity override", "notAfter", notAfterStr)
+	}
 
 	logger.Info("Enrolling certificate with EJBCA", "commonName", csr.Subject.CommonName, "dnsNames", csr.DNSNames, "ipAddresses", csr.IPAddresses, "uriSans", csr.URIs)
 


### PR DESCRIPTION
## Describe your changes

<!--- Please describe your changes in detail. Include the motivation for the changes, e.g. what problem it solves or if it fixes a bug. -->

Passes spec.duration from the cert-manager CertificateRequest to the EJBCA REST API as end_time, allowing per-certificate validity override.

Implementation notes:

- end_time is the correct EJBCA REST API v1 field name — confirmed against EJBCA 9.3.3
- Required time format is "2006-01-02 15:04:05" (UTC) — RFC3339 is silently rejected by EJBCA
- AdditionalProperties used as an escape hatch since SDK v1.0.2 predates this field
- If spec.duration is absent, behaviour is unchanged — Certificate Profile default validity is used
- Prerequisite: "Allow Validity Override" must be enabled in the EJBCA Certificate Profile

## How has this been tested?

<!--- If relevant, please describe any tests you ran to verify your changes. -->

- Build tests pass
- cert-manager requesting a cert without setting spec.duration: no changes to current behavior
- cert-manager requestign a cert with a duration: This is correctly converted into a future date, in the required format, passed to EJBCA, and accepted. EJBCA issues a certifcate with the appropriate "Not After" settings. 
- Expected entries are seen in the EJBCA syslog, and kubectl logs for ejbca-cert-manager issuer.

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [x] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).
